### PR TITLE
Fix #2: Remove event_type CHECK constraint for extensibility

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -9,6 +9,7 @@ import {
   CREATE_INDEXES_SQL,
   SEED_VERSION_SQL,
   CURRENT_SCHEMA_VERSION,
+  MIGRATE_V2_SQL,
 } from "./schema";
 import type { DbOptions } from "./types";
 import { loadConfig } from "./config";
@@ -130,16 +131,17 @@ export function migrate(db: Database): void {
   const current = getSchemaVersion(db);
 
   // Migration registry: version -> migration function
-  // Currently empty — v1 schema is created by openDatabase.
-  // Future migrations go here:
-  // const migrations: Array<{ version: number; fn: (db: Database) => void }> = [
-  //   { version: 2, fn: (db) => { db.exec("ALTER TABLE ..."); } },
-  // ];
   const migrations: Array<{
     version: number;
     description: string;
     fn: (db: Database) => void;
-  }> = [];
+  }> = [
+    {
+      version: 2,
+      description: "Remove event_type CHECK constraint (free-form event types)",
+      fn: (db) => { db.exec(MIGRATE_V2_SQL); },
+    },
+  ];
 
   const pending = migrations.filter((m) => m.version > current);
   for (const migration of pending) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { BlackboardError } from "./errors";
-import { EVENT_TYPES, type BlackboardEvent, type EventType } from "./types";
+import { type BlackboardEvent } from "./types";
 
 export interface ObserveEventsOptions {
   since?: string;
@@ -54,14 +54,6 @@ export function observeEvents(
 
   if (opts?.type) {
     const types = opts.type.split(",").map((t) => t.trim());
-    for (const t of types) {
-      if (!EVENT_TYPES.includes(t as EventType)) {
-        throw new BlackboardError(
-          `Invalid event type "${t}". Valid values: ${EVENT_TYPES.join(", ")}`,
-          "INVALID_EVENT_TYPE"
-        );
-      }
-    }
     const placeholders = types.map(() => "?").join(", ");
     conditions.push(`event_type IN (${placeholders})`);
     params.push(...types);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,8 @@ export type WorkItemPriority = (typeof WORK_ITEM_PRIORITIES)[number];
 export const WORK_ITEM_SOURCES = ["github", "local", "operator"] as const;
 export type WorkItemSource = (typeof WORK_ITEM_SOURCES)[number];
 
-// Event type values (14 types)
-export const EVENT_TYPES = [
+// Known blackboard event types (not exhaustive — downstream consumers may define their own)
+export const KNOWN_EVENT_TYPES = [
   "agent_registered",
   "agent_deregistered",
   "agent_stale",
@@ -40,7 +40,10 @@ export const EVENT_TYPES = [
   "heartbeat_received",
   "stale_locks_released",
 ] as const;
-export type EventType = (typeof EVENT_TYPES)[number];
+export type KnownEventType = (typeof KNOWN_EVENT_TYPES)[number];
+
+// Event type is free-form text — no CHECK constraint in the database
+export type EventType = string;
 
 // Target type for events
 export const TARGET_TYPES = ["agent", "work_item", "project"] as const;

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -136,9 +136,9 @@ describe("openDatabase", () => {
     closeDatabase(db);
   });
 
-  it("sets schema_version to 1", () => {
+  it("sets schema_version to current version", () => {
     const db = openDatabase(dbPath);
-    expect(getSchemaVersion(db)).toBe(1);
+    expect(getSchemaVersion(db)).toBe(2);
     closeDatabase(db);
   });
 
@@ -153,7 +153,7 @@ describe("openDatabase", () => {
       )
       .all() as { name: string }[];
     expect(tables).toHaveLength(6);
-    expect(getSchemaVersion(db2)).toBe(1);
+    expect(getSchemaVersion(db2)).toBe(2);
     closeDatabase(db2);
   });
 

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -119,9 +119,11 @@ describe("observeEvents", () => {
     expect(events.every(e => e.event_type !== "heartbeat_received")).toBe(true);
   });
 
-  test("throws on invalid event type", async () => {
+  test("accepts arbitrary event types for filtering", async () => {
     const { observeEvents } = await import("../src/events");
-    expect(() => observeEvents(db, { type: "invalid_type" })).toThrow("Invalid event type");
+    // Custom event types should not throw — downstream consumers define their own
+    const events = observeEvents(db, { type: "custom_type" });
+    expect(events).toEqual([]);
   });
 
   test("filters by --session prefix", async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -172,15 +172,15 @@ describe("createServer", () => {
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
   });
 
-  test("handles invalid filter gracefully", async () => {
+  test("accepts arbitrary event type filters", async () => {
     const { createServer } = await import("../src/server");
     server = createServer(db, dbPath, 0);
     const res = await fetch(
-      `http://localhost:${server.port}/api/events?filter=bad_type`
+      `http://localhost:${server.port}/api/events?filter=custom_type`
     );
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.ok).toBe(false);
-    expect(json.error).toContain("Invalid event type");
+    expect(json.ok).toBe(true);
+    expect(json.items).toEqual([]);
   });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -16,7 +16,7 @@ import {
   WORK_ITEM_STATUSES,
   WORK_ITEM_PRIORITIES,
   WORK_ITEM_SOURCES,
-  EVENT_TYPES,
+  KNOWN_EVENT_TYPES,
 } from "../src/types";
 
 describe("types", () => {
@@ -50,21 +50,26 @@ describe("types", () => {
   });
 
   describe("EventType", () => {
-    it("has exactly 13 values matching schema CHECK constraint", () => {
-      expect(EVENT_TYPES).toHaveLength(13);
-      expect(EVENT_TYPES).toContain("agent_registered");
-      expect(EVENT_TYPES).toContain("agent_deregistered");
-      expect(EVENT_TYPES).toContain("agent_stale");
-      expect(EVENT_TYPES).toContain("agent_recovered");
-      expect(EVENT_TYPES).toContain("work_claimed");
-      expect(EVENT_TYPES).toContain("work_released");
-      expect(EVENT_TYPES).toContain("work_completed");
-      expect(EVENT_TYPES).toContain("work_blocked");
-      expect(EVENT_TYPES).toContain("work_created");
-      expect(EVENT_TYPES).toContain("project_registered");
-      expect(EVENT_TYPES).toContain("project_updated");
-      expect(EVENT_TYPES).toContain("heartbeat_received");
-      expect(EVENT_TYPES).toContain("stale_locks_released");
+    it("KNOWN_EVENT_TYPES lists 13 known blackboard event types", () => {
+      expect(KNOWN_EVENT_TYPES).toHaveLength(13);
+      expect(KNOWN_EVENT_TYPES).toContain("agent_registered");
+      expect(KNOWN_EVENT_TYPES).toContain("agent_deregistered");
+      expect(KNOWN_EVENT_TYPES).toContain("agent_stale");
+      expect(KNOWN_EVENT_TYPES).toContain("agent_recovered");
+      expect(KNOWN_EVENT_TYPES).toContain("work_claimed");
+      expect(KNOWN_EVENT_TYPES).toContain("work_released");
+      expect(KNOWN_EVENT_TYPES).toContain("work_completed");
+      expect(KNOWN_EVENT_TYPES).toContain("work_blocked");
+      expect(KNOWN_EVENT_TYPES).toContain("work_created");
+      expect(KNOWN_EVENT_TYPES).toContain("project_registered");
+      expect(KNOWN_EVENT_TYPES).toContain("project_updated");
+      expect(KNOWN_EVENT_TYPES).toContain("heartbeat_received");
+      expect(KNOWN_EVENT_TYPES).toContain("stale_locks_released");
+    });
+
+    it("EventType is string (free-form, not constrained)", () => {
+      const customType: EventType = "heartbeat_check";
+      expect(typeof customType).toBe("string");
     });
   });
 


### PR DESCRIPTION
Fixes #2

Removes the restrictive CHECK constraint on `event_type` so downstream consumers (like ivy-heartbeat) can use custom event types without being blocked by the schema.

## Changes
- Relaxed event_type constraint in schema
- Updated types to support extensible event types
- Updated tests to reflect new behavior