### PR TITLE
Fix #30: project register upserts instead of erroring

### DIFF
--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -34,11 +34,12 @@ export function registerProjectCommands(
         if (ctx.options.json) {
           console.log(formatJson(result));
         } else {
-          console.log(`Registered project ${result.project_id}`);
+          const verb = result.updated ? "Updated" : "Registered";
+          console.log(`${verb} project ${result.project_id}`);
           console.log(`Name: ${result.display_name}`);
           if (result.local_path) console.log(`Path: ${result.local_path}`);
           if (result.remote_repo) console.log(`Repo: ${result.remote_repo}`);
-          console.log(`At:   ${result.registered_at}`);
+          if (!result.updated) console.log(`At:   ${result.registered_at}`);
         }
       }, () => getContext().options.json)
     );


### PR DESCRIPTION
## Summary
- `registerProject()` now performs upsert: updates existing projects instead of throwing `PROJECT_EXISTS`
- Only overwrites fields that were explicitly provided; preserves unspecified fields
- Emits `project_updated` event for updates, `project_registered` for new registrations
- CLI shows "Updated project" vs "Registered project" accordingly

## Test plan
- [x] Existing test updated: "throws on duplicate" → "upserts on duplicate"
- [x] New test: partial field updates preserve unspecified fields
- [x] New test: upsert emits `project_updated` event
- [x] New test: metadata can be updated on existing project (the `specflow_enabled` use case)
- [x] Full test suite: 362 pass, 0 fail

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)